### PR TITLE
Add upload ingestion flow

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -17,7 +17,10 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 import datarobot as dr
 import streamlit as st
@@ -120,6 +123,29 @@ def render_answer_and_citations(container: DeltaGenerator, response: RAGOutput) 
 def main() -> None:
     render_svg(svg)
     st.title(app_settings.page_title)
+
+    uploaded_files = st.file_uploader(
+        gettext("Upload documents"),
+        type=["pdf", "docx"],
+        accept_multiple_files=True,
+    )
+
+    if uploaded_files:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for uploaded_file in uploaded_files:
+                file_path = Path(tmpdir) / uploaded_file.name
+                file_path.write_bytes(uploaded_file.read())
+
+            with st.spinner(gettext("Ingesting uploaded documents...")):
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "scripts/ingest_docs.py",
+                        tmpdir,
+                    ],
+                    check=False,
+                )
+        st.success(gettext("Document ingestion complete."))
 
     chat_container = st.container()
     prompt_container = st.container()


### PR DESCRIPTION
## Summary
- allow PDF and DOCX uploads in the Streamlit app
- run `scripts/ingest_docs.py` on uploaded files and show a progress spinner

## Testing
- `ruff format --check .`
- `ruff check .`
- `mypy --pretty --install-types --non-interactive frontend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68473d7933b483228dfdb3715b5d1de6